### PR TITLE
Fix signature encoding

### DIFF
--- a/lib/gcs_signed_url.ex
+++ b/lib/gcs_signed_url.ex
@@ -50,7 +50,7 @@ defmodule GcsSignedUrl do
     %StringToSign{string_to_sign: string_to_sign, url_template: url_template} =
       StringToSign.generate_v2(client_email, bucket, filename, opts)
 
-    signature = Crypto.sign(string_to_sign, client) |> Base.encode64()
+    signature = Crypto.sign(string_to_sign, client) |> Base.encode64() |> URI.encode_www_form()
     String.replace(url_template, "#SIGNATURE#", signature)
   end
 


### PR DESCRIPTION
It seems that GCP requires percent encoding for characters such as `+`
and `/`, or otherwise the request will fail with a complaint that
the Signature was not base64 encoded.

Related issue: https://github.com/alexandrubagu/gcs_signed_url/issues/7