### PR TITLE
Use RFC 3986 query encoding

### DIFF
--- a/lib/gcs_signed_url/query_string.ex
+++ b/lib/gcs_signed_url/query_string.ex
@@ -30,6 +30,22 @@ defmodule GcsSignedUrl.QueryString do
        "X-Goog-Expires": expires
      ] ++ additional_query_params)
     |> Enum.sort()
-    |> URI.encode_query()
+    |> encode_query_rfc3986()
+  end
+
+  @spec encode_query_rfc3986(Enumerable.t()) :: String.t()
+  def encode_query_rfc3986(pairs) do
+    # We should encode a space as '%20'.
+    # Elixir 1.12+ exposes this choice in URI.encode_query/2 as the second parameter, see the docs
+    # at https://hexdocs.pm/elixir/1.12/URI.html#encode_query/2.
+    # The code below replicates the implementation in Elixir 1.12.
+    Enum.map_join(pairs, "&", &encode_kv_pair_rfc3986/1)
+  end
+
+  # taken from
+  # https://github.com/elixir-lang/elixir/blob/03859fb92edc56a1cb5d7436b6bec282156198dc/lib/elixir/lib/uri.ex#L128-L131
+  defp encode_kv_pair_rfc3986({key, value}) do
+    URI.encode(Kernel.to_string(key), &URI.char_unreserved?/1) <>
+      "=" <> URI.encode(Kernel.to_string(value), &URI.char_unreserved?/1)
   end
 end

--- a/lib/gcs_signed_url/string_to_sign.ex
+++ b/lib/gcs_signed_url/string_to_sign.ex
@@ -92,7 +92,7 @@ defmodule GcsSignedUrl.StringToSign do
         "GoogleAccessId" => client_email,
         "Expires" => expires
       }
-      |> URI.encode_query()
+      |> QueryString.encode_query_rfc3986()
 
     string_to_sign = "#{verb}\n#{md5_digest}\n#{content_type}\n#{expires}\n#{resource}"
     url_template = "https://#{@host}#{resource}?#{query_string}&Signature=#SIGNATURE#"

--- a/test/gcs_signed_url/query_string_test.exs
+++ b/test/gcs_signed_url/query_string_test.exs
@@ -15,10 +15,10 @@ defmodule GcsSignedUrl.QueryStringTest do
           iso_date_time,
           headers,
           500,
-          foo: "bar"
+          foo: "bar and baz"
         )
 
-      assert "X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=project%40gcs_signed_url.iam.gserviceaccount.com%2Fsome-credential-scope&X-Goog-Date=some-date-time&X-Goog-Expires=500&X-Goog-SignedHeaders=some-signed-headers&foo=bar" ==
+      assert "X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=project%40gcs_signed_url.iam.gserviceaccount.com%2Fsome-credential-scope&X-Goog-Date=some-date-time&X-Goog-Expires=500&X-Goog-SignedHeaders=some-signed-headers&foo=bar%20and%20baz" ==
                query_string
     end
   end


### PR DESCRIPTION
We stumbled upon this issue when we used the `response-content-disposition` query parameter (https://cloud.google.com/storage/docs/xml-api/reference-headers#responsecontentdisposition). Without this PR, the signed URL is rejected by Google. Upon further inspection we noticed that Google encoded the space character as `%20`, while the library encoded it as `+`.

This PR changes the query encoding to follow RFC 3986, which, among other things, means that spaces are encoded as `%20` instead of `+`.
