### PR TITLE
Accept map with atoms for `GcsSignedUrl.Client.load`

### DIFF
--- a/lib/gcs_signed_url/client.ex
+++ b/lib/gcs_signed_url/client.ex
@@ -24,15 +24,22 @@ defmodule GcsSignedUrl.Client do
       iex> GcsSignedUrl.Client.load(service_account)
       %GcsSignedUrl.Client{...}
 
+      iex> client = GcsSignedUrl.Client.load(%{private_key: "...", client_email: "..."})
+      %GcsSignedUrl.Client{...}
+
       iex> GcsSignedUrl.Client.load("/home/alexandrubagu/config/google.json")
       %GcsSignedUrl.Client{...}
 
   """
   @spec load(map() | String.t()) :: __MODULE__.t()
-  def load(%{
-        "private_key" => private_key,
-        "client_email" => client_email
-      }) do
+  def load(%{"private_key" => private_key, "client_email" => client_email}) do
+    %__MODULE__{
+      private_key: private_key,
+      client_email: client_email
+    }
+  end
+
+  def load(%{private_key: private_key, client_email: client_email}) do
     %__MODULE__{
       private_key: private_key,
       client_email: client_email

--- a/test/gcs_signed_url/client_test.exs
+++ b/test/gcs_signed_url/client_test.exs
@@ -14,6 +14,11 @@ defmodule GcsSignedUrl.ClientTest do
       assert client == Fixtures.client_from_json()
     end
 
+    test "returns correct data for correct map" do
+      client = MUT.load(Fixtures.client_from_json())
+      assert client == Fixtures.client_from_json()
+    end
+
     test "returns error for inexisting file" do
       assert {:error, _} = MUT.load("some_path/data.txt")
     end


### PR DESCRIPTION
According to some documentation the following should be possible: `GcsSignedUrl.Client.load(%{private_key: "...", client_email: "..."})`. But when doing the following it returns an error tuple `{:error, "Please provide a path for config"}`.

```ex
client = GcsSignedUrl.Client.load(%{private_key: "...", client_email: "..."})
GcsSignedUrl.generate(client, bucket, recording_name)
``` 