### PR TITLE
Add support for custom hostnames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Changed
 
 - Use `Kernel.hd/1` insead of `(fn [x] -> x end).()` to pick the first (only) item in the list.
+- Add optional `:host` to `generate_v4/3` opts. See [Domain-named buckets](https://cloud.google.com/storage/docs/domain-name-verification) in the Google Cloud docs for more info.
+
 
 ## [0.4.4] - 2021-11-19
 

--- a/lib/gcs_signed_url.ex
+++ b/lib/gcs_signed_url.ex
@@ -17,7 +17,8 @@ defmodule GcsSignedUrl do
           headers: Keyword.t(),
           query_params: Keyword.t(),
           valid_from: DateTime.t(),
-          expires: integer
+          expires: integer,
+          host: String.t()
         ]
 
   @deprecated "Use GcsSignedUrl.generate_v4/4 instead. [V2 signing process is considered legacy](https://cloud.google.com/storage/docs/access-control/signed-urls-v2)"

--- a/lib/gcs_signed_url/string_to_sign.ex
+++ b/lib/gcs_signed_url/string_to_sign.ex
@@ -100,7 +100,9 @@ defmodule GcsSignedUrl.StringToSign do
       |> QueryString.encode_query_rfc3986()
 
     string_to_sign = "#{verb}\n#{md5_digest}\n#{content_type}\n#{expires}\n#{resource}"
-    url_template = "https://#{@google_cloud_storage_host}#{resource}?#{query_string}&Signature=#SIGNATURE#"
+
+    url_template =
+      "https://#{@google_cloud_storage_host}#{resource}?#{query_string}&Signature=#SIGNATURE#"
 
     %__MODULE__{
       string_to_sign: string_to_sign,

--- a/test/gcs_signed_url/string_to_sign_test.exs
+++ b/test/gcs_signed_url/string_to_sign_test.exs
@@ -22,12 +22,17 @@ defmodule GcsSignedUrl.StringToSignTest do
       %MUT{string_to_sign: string_to_sign, url_template: url_template} =
         MUT.generate_v4("project@gcs_signed_url.iam.gserviceaccount.com", "bucket", "object.jpg",
           valid_from: valid_from,
-          expires: 123
+          expires: 123,
+          host: "bucket.example.com"
         )
 
       string_to_sign_parts = String.split(string_to_sign, "\n")
+      url_template_parts = String.split(url_template, "/")
 
       assert url_template =~ ~r/#SIGNATURE#/
+      assert url_template =~ "https://bucket.example.com"
+      assert [_https, _empty, "bucket.example.com", _object_not_bucket] = url_template_parts
+
       assert 4 == Enum.count(string_to_sign_parts)
       assert "GOOG4-RSA-SHA256" == Enum.at(string_to_sign_parts, 0)
     end

--- a/test/gcs_signed_url/string_to_sign_test.exs
+++ b/test/gcs_signed_url/string_to_sign_test.exs
@@ -22,7 +22,19 @@ defmodule GcsSignedUrl.StringToSignTest do
       %MUT{string_to_sign: string_to_sign, url_template: url_template} =
         MUT.generate_v4("project@gcs_signed_url.iam.gserviceaccount.com", "bucket", "object.jpg",
           valid_from: valid_from,
-          expires: 123,
+          expires: 123
+        )
+
+      string_to_sign_parts = String.split(string_to_sign, "\n")
+
+      assert url_template =~ ~r/#SIGNATURE#/
+      assert 4 == Enum.count(string_to_sign_parts)
+      assert "GOOG4-RSA-SHA256" == Enum.at(string_to_sign_parts, 0)
+    end
+
+    test "Generates string to sign and URL with custom domain" do
+      %MUT{string_to_sign: string_to_sign, url_template: url_template} =
+        MUT.generate_v4("project@gcs_signed_url.iam.gserviceaccount.com", "bucket", "object.jpg",
           host: "bucket.example.com"
         )
 

--- a/test/gcs_signed_url/string_to_sign_test.exs
+++ b/test/gcs_signed_url/string_to_sign_test.exs
@@ -27,11 +27,9 @@ defmodule GcsSignedUrl.StringToSignTest do
         )
 
       string_to_sign_parts = String.split(string_to_sign, "\n")
-      url_template_parts = String.split(url_template, "/")
 
       assert url_template =~ ~r/#SIGNATURE#/
       assert url_template =~ "https://bucket.example.com"
-      assert [_https, _empty, "bucket.example.com", _object_not_bucket] = url_template_parts
 
       assert 4 == Enum.count(string_to_sign_parts)
       assert "GOOG4-RSA-SHA256" == Enum.at(string_to_sign_parts, 0)


### PR DESCRIPTION
This PR adds support to use custom hostnames instead of [storage.googleapis.com](https://storage.googleapis.com). When using a custom hostname the bucket is removed from the path, and that hostname is used as host in the generated signed URL. 

See [Domain-named buckets](https://cloud.google.com/storage/docs/domain-name-verification) in the Google Cloud docs for more info.