### PR TITLE
Fix dialyzer error when the HTTP client is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed
+
+- Use `Application.get_env/3` instead of `Application.compile_env/3` to avoid dialyzer errors.
+
+
 ## [0.5.0] - 2023-09-25
 
 ### Chores

--- a/lib/gcs_signed_url/crypto.ex
+++ b/lib/gcs_signed_url/crypto.ex
@@ -5,12 +5,6 @@ defmodule GcsSignedUrl.Crypto do
 
   alias GcsSignedUrl.{Client, SignBlob}
 
-  @sign_blob_http Application.compile_env(
-                    :gcs_signed_url,
-                    GcsSignedUrl.SignBlob.HTTP,
-                    GcsSignedUrl.SignBlob.HTTP
-                  )
-
   @doc """
   If you pass a `%GcsSignedUrl.Client{}` as second argument, this function signs the given string with the given
   client's private key.
@@ -48,7 +42,14 @@ defmodule GcsSignedUrl.Crypto do
   defp do_post_request(string_to_sign, oauth_config) do
     payload = Base.encode64(string_to_sign)
 
-    @sign_blob_http.post(
+    sign_blob_http =
+      Application.get_env(
+        :gcs_signed_url,
+        GcsSignedUrl.SignBlob.HTTP,
+        GcsSignedUrl.SignBlob.HTTP
+      )
+
+    sign_blob_http.post(
       oauth_config.service_account,
       %{payload: payload},
       Authorization: "Bearer #{oauth_config.access_token}"


### PR DESCRIPTION
In the moment dialyzer is analyzing `gcs_signed_url`  and dependencies, the module set as the `GcsSignedUrl.SignBlob.HTTP`  client may not be available. Today this causes dialyzer to think all calls to `GcsSignedUrl.Crypto.sign/2` will fail because the code is using `Application.compile_env`. 

Using `Application.fetch_env` avoids these dialyzer errors.

---

<!-- In order for this pull request to be merged it has to fulfill the following requirements: -->

#### Requirements

- [X] Entry in CHANGELOG.md was created
- [ ] Link to documentation is provided in the PR description
- [ ] Functionality is covered by newly created tests
